### PR TITLE
ci: add GitHub Actions for CI and npm/GitHub release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,29 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npm test
+
+  smoke:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:smoke
+
+  consumer:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run test:smoke:consumer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Read version
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+
+      - name: Skip if version already on npm
+        id: check
+        run: |
+          if npm view "nestjs-xotp@${{ steps.version.outputs.version }}" version 2>/dev/null; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "nestjs-xotp@${{ steps.version.outputs.version }} already published — skipping"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.check.outputs.skip != 'true'
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.skip != 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run build
+      - run: npm run test:smoke
+      - run: npm run test:smoke:consumer
 
       - name: Skip if version already on npm
         id: check

--- a/package.json
+++ b/package.json
@@ -6,11 +6,16 @@
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "lint": "eslint src/**/*.ts",
     "test": "jest",
     "prebuild": "rimraf dist/*",
-    "build": "nest build -p tsconfig.build.json"
+    "build": "tsc -p tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "lint": "eslint src/**/*.ts",
     "test": "jest",
+    "test:smoke": "node tests/smoke/cjs.cjs",
+    "test:smoke:consumer": "node scripts/test-smoke-consumer.mjs",
     "prebuild": "rimraf dist/*",
     "build": "tsc -p tsconfig.build.json"
   },

--- a/scripts/test-smoke-consumer.mjs
+++ b/scripts/test-smoke-consumer.mjs
@@ -1,0 +1,59 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(__dirname, '..');
+const checksCjs = join(rootDir, 'tests/smoke/checks.cjs');
+const tmpDir = mkdtempSync(join(tmpdir(), 'nestjs-xotp-smoke-consumer-'));
+
+try {
+  writeFileSync(
+    join(tmpDir, 'package.json'),
+    JSON.stringify(
+      {
+        private: true,
+        type: 'commonjs',
+        dependencies: {
+          'nestjs-xotp': `file:${rootDir}`,
+          '@nestjs/common': '^11.0.0',
+          '@nestjs/core': '^11.0.0',
+          '@nestjs/testing': '^11.0.0',
+          xotp: '^1.1.0',
+        },
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+
+  writeFileSync(
+    join(tmpDir, 'test.cjs'),
+    `const { runChecks } = require(${JSON.stringify(checksCjs)});\n` +
+      'runChecks(require("nestjs-xotp"))\n' +
+      '  .then(() => console.log("smoke (cjs, package): ok"))\n' +
+      '  .catch((error) => {\n' +
+      '    console.error(error);\n' +
+      '    process.exit(1);\n' +
+      '  });\n',
+  );
+
+  const install = spawnSync('npm', ['install', '--ignore-scripts'], {
+    cwd: tmpDir,
+    stdio: 'inherit',
+  });
+  if (install.status !== 0) process.exit(install.status ?? 1);
+
+  const run = spawnSync('node', ['test.cjs'], {
+    cwd: tmpDir,
+    stdio: 'inherit',
+  });
+  if (run.status !== 0) {
+    console.error(`Consumer smoke failed. Temp dir: ${tmpDir}`);
+    process.exit(run.status ?? 1);
+  }
+} finally {
+  rmSync(tmpDir, { recursive: true, force: true });
+}

--- a/tests/smoke/checks.cjs
+++ b/tests/smoke/checks.cjs
@@ -1,0 +1,53 @@
+const TOTP_SECRET = '12345678901234567890';
+const TOTP_TIMESTAMP_MS = 59 * 1000;
+const TOTP_TOKEN = '94287082';
+const HOTP_TOKEN = '755224';
+
+async function runChecks({ XOTPModule, XOTPService }) {
+  require('reflect-metadata');
+
+  const { Test } = require('@nestjs/testing');
+  const { Secret } = require('xotp');
+
+  const module = await Test.createTestingModule({
+    imports: [
+      XOTPModule.forRoot({
+        totp: { algorithm: 'sha1', digits: 8, duration: 30 },
+        hotp: { algorithm: 'sha1', digits: 6 },
+      }),
+    ],
+  }).compile();
+
+  try {
+    const xotpService = module.get(XOTPService);
+    const secret = Secret.from(TOTP_SECRET, 'ascii');
+    const token = xotpService.totp.generate({
+      secret,
+      timestamp: TOTP_TIMESTAMP_MS,
+    });
+
+    if (token !== TOTP_TOKEN) {
+      throw new Error(`TOTP generate: expected ${TOTP_TOKEN}, got ${token}`);
+    }
+
+    if (
+      !xotpService.totp.validate({
+        token,
+        secret,
+        timestamp: TOTP_TIMESTAMP_MS,
+      })
+    ) {
+      throw new Error('TOTP validate failed');
+    }
+
+    const hotpToken = xotpService.hotp.generate({ secret, counter: 0 });
+
+    if (hotpToken !== HOTP_TOKEN) {
+      throw new Error(`HOTP generate: expected ${HOTP_TOKEN}, got ${hotpToken}`);
+    }
+  } finally {
+    await module.close();
+  }
+}
+
+module.exports = { runChecks };

--- a/tests/smoke/cjs.cjs
+++ b/tests/smoke/cjs.cjs
@@ -1,0 +1,10 @@
+const { runChecks } = require('./checks.cjs');
+
+runChecks(require('../../dist/index.js'))
+  .then(() => {
+    console.log('smoke (cjs, dist): ok');
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Adds release automation for nestjs-xotp, following the same pattern as xotp.

- **CI** — runs on PRs and pushes to `main` (`npm ci`, build, test)
- **Publish** — on push to `main` or manual dispatch: test → build → publish to npm → create GitHub Release
- Skips publish if the current `package.json` version is already on npm
- Adds npm `files` whitelist (`dist/`, `LICENSE`, `README.md`)
- Switches build to `tsc -p tsconfig.build.json` so CI works without a global Nest CLI

## Setup required

Add GitHub repo secret **`NPM_TOKEN`** (npm automation token with publish access).

## Test plan

- [x] `npm run build`
- [x] `npm test`
- [ ] Verify CI passes on this PR
- [ ] After merge, confirm publish skips until `package.json` version is bumped