### PR TITLE
examples: add Docker Compose setup for runnable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,40 @@ The app listens on `http://localhost:3000`. See [examples/2fa-basic/README.md](.
 
 Each example depends on the local package (`"nestjs-xotp": "file:../.."`), so run `npm run build` at the repo root before `npm install` inside an example.
 
+### Run with Docker Compose (optional)
+
+Requires [Docker](https://docs.docker.com/get-docker/). No local `npm install` or `npm run build` is needed — the image builds the library and example from source.
+
+From the repository root:
+
+```bash
+# Build and run one example (foreground)
+docker compose -f examples/docker-compose.yml up 2fa-basic
+
+# Build and run in the background
+docker compose -f examples/docker-compose.yml up -d 2fa-basic
+
+# Build images only
+docker compose -f examples/docker-compose.yml build
+
+# Stop containers
+docker compose -f examples/docker-compose.yml down
+```
+
+| Service | URL | Per-example docs |
+|---------|-----|------------------|
+| `2fa-basic` | http://localhost:3000 | [README](./examples/2fa-basic/README.md) |
+| `async-config` | http://localhost:3001 | [README](./examples/async-config/README.md) |
+| `hotp-counter` | http://localhost:3002 | [README](./examples/hotp-counter/README.md) |
+
+Run every example at once:
+
+```bash
+docker compose -f examples/docker-compose.yml up
+```
+
+npm is the primary workflow for development and copying code into your own app. See [examples/README.md](./examples/README.md) for more detail.
+
 ### Snippets
 
 Inject `XOTPTOTPService` (or `XOTPService`) and pass each user's secret per call:

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,8 +1,3 @@
-# Build context: repository root (see examples/docker-compose.yml)
-#
-# The library is packed with npm pack so examples install a tarball instead of
-# file:../.. (avoids separate peer-dependency wiring in the runner image).
-
 ARG EXAMPLE=2fa-basic
 
 FROM node:22-alpine AS builder

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,45 @@
+# Build context: repository root (see examples/docker-compose.yml)
+#
+# The library is packed with npm pack so examples install a tarball instead of
+# file:../.. (avoids separate peer-dependency wiring in the runner image).
+
+ARG EXAMPLE=2fa-basic
+
+FROM node:22-alpine AS builder
+
+ARG EXAMPLE
+
+WORKDIR /workspace
+
+COPY package.json package-lock.json ./
+COPY tsconfig.json tsconfig.build.json LICENSE README.md ./
+COPY src ./src
+
+RUN npm ci && npm run build && npm pack && mv nestjs-xotp-*.tgz /workspace/nestjs-xotp.tgz
+
+WORKDIR /workspace/examples/${EXAMPLE}
+
+COPY examples/${EXAMPLE}/package.json examples/${EXAMPLE}/package-lock.json ./
+COPY examples/${EXAMPLE}/tsconfig.json examples/${EXAMPLE}/tsconfig.build.json ./
+COPY examples/${EXAMPLE}/src ./src
+
+RUN sed -i 's|"nestjs-xotp": "file:../.."|"nestjs-xotp": "file:../../nestjs-xotp.tgz"|' package.json \
+  && npm install \
+  && npm run build \
+  && npm prune --omit=dev
+
+FROM node:22-alpine AS runner
+
+ARG EXAMPLE
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY --from=builder /workspace/examples/${EXAMPLE}/package.json /workspace/examples/${EXAMPLE}/package-lock.json ./
+COPY --from=builder /workspace/examples/${EXAMPLE}/dist ./dist
+COPY --from=builder /workspace/examples/${EXAMPLE}/node_modules ./node_modules
+
+EXPOSE 3000
+
+CMD ["node", "dist/main.js"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,38 @@ npm install
 npm run start
 ```
 
-Each example depends on the local package (`"nestjs-xotp": "file:../.."`), so build the library at the repo root before installing inside an example.
+Each example depends on the local package (`"nestjs-xotp": "file:../.."`), so run `npm run build` at the repo root before `npm install` inside an example.
+
+## Docker (optional)
+
+Requires [Docker](https://docs.docker.com/get-docker/). The container build compiles `nestjs-xotp` and the selected example — no local `npm install` or `npm run build` required.
+
+From the repository root:
+
+```bash
+# One example (foreground)
+docker compose -f examples/docker-compose.yml up 2fa-basic
+
+# One example (background)
+docker compose -f examples/docker-compose.yml up -d async-config
+
+# All examples
+docker compose -f examples/docker-compose.yml up
+
+# Build images without starting
+docker compose -f examples/docker-compose.yml build
+
+# Stop and remove containers
+docker compose -f examples/docker-compose.yml down
+```
+
+| Service | Port | Docs |
+|---------|------|------|
+| `2fa-basic` | 3000 | [README](./2fa-basic/README.md) |
+| `async-config` | 3001 | [README](./async-config/README.md) |
+| `hotp-counter` | 3002 | [README](./hotp-counter/README.md) |
+
+npm is the primary workflow for development and copying code into your own app.
 
 ## Examples
 

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  2fa-basic:
+    build:
+      context: ..
+      dockerfile: examples/Dockerfile
+      args:
+        EXAMPLE: 2fa-basic
+    ports:
+      - '3000:3000'
+    environment:
+      PORT: 3000
+
+  async-config:
+    build:
+      context: ..
+      dockerfile: examples/Dockerfile
+      args:
+        EXAMPLE: async-config
+    ports:
+      - '3001:3001'
+    environment:
+      PORT: 3001
+
+  hotp-counter:
+    build:
+      context: ..
+      dockerfile: examples/Dockerfile
+      args:
+        EXAMPLE: hotp-counter
+    ports:
+      - '3002:3002'
+    environment:
+      PORT: 3002


### PR DESCRIPTION
## Summary
- Add a shared `examples/Dockerfile` that builds `nestjs-xotp` and any example via the `EXAMPLE` build arg
- Add `examples/docker-compose.yml` with one service per example (`2fa-basic`, `async-config`, `hotp-counter`)
- Document Docker usage in the root and `examples/` READMEs (npm remains the recommended workflow)
## How it works
- **Build context:** repository root
- **Builder stage:** compiles the library, runs `npm pack`, installs the example from the tarball (Docker-only; local dev still uses `file:../..`)
- **Runner stage:** production `dist` + `node_modules` only
| Service | Port |
|---------|------|
| `2fa-basic` | 3000 |
| `hotp-counter` | 3002 |
| `async-config` | 3001 |
## Usage
From the repository root:
```bash
docker compose -f examples/docker-compose.yml up 2fa-basic
docker compose -f examples/docker-compose.yml up      # all examples
docker compose -f examples/docker-compose.yml build   # build only