### PR TITLE
docs: add README cookbook section and table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@
 
 `nestjs-xotp` provides a convenient way to use the XOTP library within your NestJS applications. It fully leverages NestJS's powerful dependency injection system, making it easy to manage, generate, and validate OTPs (Time-based One-Time Passwords - TOTP, and HMAC-based One-Time Passwords - HOTP) for robust security within your services.
 
+## Table of contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Examples](#examples)
+- [Cookbook](#cookbook)
+- [Options](#options)
+- [License](#license)
+
 ## Installation
 
 ```bash
@@ -96,7 +105,45 @@ The app listens on `http://localhost:3000`. See [examples/2fa-basic/README.md](.
 
 Each example depends on the local package (`"nestjs-xotp": "file:../.."`), so run `npm run build` at the repo root before `npm install` inside an example.
 
-### Snippets
+### Run with Docker Compose (optional)
+
+Requires [Docker](https://docs.docker.com/get-docker/). No local `npm install` or `npm run build` is needed — the image builds the library and example from source.
+
+From the repository root:
+
+```bash
+# Build and run one example (foreground)
+docker compose -f examples/docker-compose.yml up 2fa-basic
+
+# Build and run in the background
+docker compose -f examples/docker-compose.yml up -d 2fa-basic
+
+# Build images only
+docker compose -f examples/docker-compose.yml build
+
+# Stop containers
+docker compose -f examples/docker-compose.yml down
+```
+
+| Service | URL | Per-example docs |
+|---------|-----|------------------|
+| `2fa-basic` | http://localhost:3000 | [README](./examples/2fa-basic/README.md) |
+| `async-config` | http://localhost:3001 | [README](./examples/async-config/README.md) |
+| `hotp-counter` | http://localhost:3002 | [README](./examples/hotp-counter/README.md) |
+
+Run every example at once:
+
+```bash
+docker compose -f examples/docker-compose.yml up
+```
+
+npm is the primary workflow for development and copying code into your own app. See [examples/README.md](./examples/README.md) for more detail.
+
+## Cookbook
+
+Copy-paste patterns for common integrations. For runnable NestJS apps, see [Examples](#examples) above.
+
+### Verify a TOTP token
 
 Inject `XOTPTOTPService` (or `XOTPService`) and pass each user's secret per call:
 
@@ -117,6 +164,8 @@ export class AuthService {
   }
 }
 ```
+
+### Enroll a user (TOTP)
 
 For enrollment, create a bound instance and export the key URI:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,8 @@
 
 Runnable NestJS apps that demonstrate `nestjs-xotp`.
 
+For copy-paste patterns without running an app, see the [Cookbook](../README.md#cookbook) section in the root README.
+
 ## Run with npm (recommended)
 
 From the repository root:
@@ -13,7 +15,38 @@ npm install
 npm run start
 ```
 
-Each example depends on the local package (`"nestjs-xotp": "file:../.."`), so build the library at the repo root before installing inside an example.
+Each example depends on the local package (`"nestjs-xotp": "file:../.."`), so run `npm run build` at the repo root before `npm install` inside an example.
+
+## Docker (optional)
+
+Requires [Docker](https://docs.docker.com/get-docker/). The container build compiles `nestjs-xotp` and the selected example — no local `npm install` or `npm run build` required.
+
+From the repository root:
+
+```bash
+# One example (foreground)
+docker compose -f examples/docker-compose.yml up 2fa-basic
+
+# One example (background)
+docker compose -f examples/docker-compose.yml up -d async-config
+
+# All examples
+docker compose -f examples/docker-compose.yml up
+
+# Build images without starting
+docker compose -f examples/docker-compose.yml build
+
+# Stop and remove containers
+docker compose -f examples/docker-compose.yml down
+```
+
+| Service | Port | Docs |
+|---------|------|------|
+| `2fa-basic` | 3000 | [README](./2fa-basic/README.md) |
+| `async-config` | 3001 | [README](./async-config/README.md) |
+| `hotp-counter` | 3002 | [README](./hotp-counter/README.md) |
+
+npm is the primary workflow for development and copying code into your own app.
 
 ## Examples
 


### PR DESCRIPTION
## Summary
- Add a table of contents to the root README
- Promote **Snippets** to a top-level **Cookbook** section with clearer recipe headings
- Link from `examples/README.md` to the cookbook for copy-paste patterns